### PR TITLE
feat(*): Support children as text nodes adjacent to tags

### DIFF
--- a/examples/hello/index.jsx
+++ b/examples/hello/index.jsx
@@ -1,4 +1,4 @@
 import { davey } from "davey";
 import { render } from "davey-dom";
 
-render(<h1>Hello <span>cray</span> world!</h1>, document.querySelector("#root"));
+render(<h1>Hello world!</h1>, document.querySelector("#root"));

--- a/examples/hello/index.jsx
+++ b/examples/hello/index.jsx
@@ -1,4 +1,4 @@
 import { davey } from "davey";
 import { render } from "davey-dom";
 
-render(<h1>Hello world!</h1>, document.querySelector("#root"));
+render(<h1>Hello <span>cray</span> world!</h1>, document.querySelector("#root"));

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "transform": {
       "^.+\\.tsx?$": "ts-jest"
     },
-    "packages": ["<rootDir>/packages/*"],
     "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
     "moduleFileExtensions": ["ts", "tsx", "js", "jsx", "json", "node"],
     "moduleNameMapper": {

--- a/packages/davey-dom/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/davey-dom/__tests__/__snapshots__/index.spec.tsx.snap
@@ -22,3 +22,18 @@ exports[`Basic single element match snapshot 1`] = `
   </h1>
 </body>
 `;
+
+exports[`Resolves text nodes match snapshot 1`] = `
+<body>
+  <h1>
+    hello 
+    <span>
+      my
+    </span>
+    <h2>
+      world
+    </h2>
+    friend
+  </h1>
+</body>
+`;

--- a/packages/davey-dom/__tests__/index.spec.tsx
+++ b/packages/davey-dom/__tests__/index.spec.tsx
@@ -33,3 +33,52 @@ describe("2-level deep nested element", () => {
     expect(document.body.querySelector("h1").textContent).toEqual("hello");
   });
 });
+
+describe("Resolves text nodes", () => {
+  beforeAll(() => {
+    render(
+      <h1>
+        hello <span>my</span>
+        <h2>world</h2>
+        friend
+      </h1>,
+      document.body
+    );
+  });
+
+  test("match snapshot", () => {
+    expect(document.body).toMatchSnapshot();
+  });
+
+  test("have hello", () => {
+    expect(document.body.querySelector("span").textContent).toEqual("my");
+  });
+});
+
+describe("Appends attributes", () => {
+  beforeAll(() => {
+    render(
+      <button
+        onClick={() => expect(true).toEqual(true)}
+        onBlur={() => expect(true).toEqual(true)}
+        style={{ backgroundColor: "blue" }}
+      >
+        hello
+      </button>,
+      document.body
+    );
+  });
+  test("onClick works", () => {
+    document.body.querySelector("button").click();
+  });
+
+  test("onBlur works", () => {
+    document.body.querySelector("button").blur();
+  });
+
+  test("style works", () => {
+    expect(
+      document.body.querySelector("button").style["background-color"]
+    ).toBe("blue");
+  });
+});

--- a/packages/davey-dom/src/render.ts
+++ b/packages/davey-dom/src/render.ts
@@ -28,11 +28,14 @@ const renderClient = ([tag, { children, ...props }]) => {
   const parent = document.createElement(tag);
   eachKey(props, (val, key) => getAttrFnClient(key)(parent, val, key));
 
-  if (Array.isArray(children) && typeof children[0] !== "string") {
+  if (Array.isArray(children)) {
     children.forEach(child => {
-      if (!child) return;
-      const [tag, { children = [], ...props }] = child;
-      parent.appendChild(renderClient([tag, { ...props, children }]));
+      if (typeof child === "string") {
+        parent.appendChild(document.createTextNode(child));
+      } else {
+        parent.appendChild(renderClient(child));
+      }
+      return;
     });
   } else {
     parent.appendChild(document.createTextNode(children));

--- a/packages/davey-server/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/davey-server/__tests__/__snapshots__/index.spec.tsx.snap
@@ -18,3 +18,16 @@ exports[`Basic single element match snapshot 1`] = `
 	hello
 </h1>"
 `;
+
+exports[`Resolves text nodes  match snapshot 1`] = `
+"<h1>
+	hello 
+	<span>
+		my
+	</span>
+	<h2>
+		world
+	</h2>
+	friend
+</h1>"
+`;

--- a/packages/davey-server/__tests__/index.spec.tsx
+++ b/packages/davey-server/__tests__/index.spec.tsx
@@ -21,3 +21,17 @@ describe("2-level deep nested element", () => {
     ).toMatchSnapshot();
   });
 });
+
+describe("Resolves text nodes ", () => {
+  test("match snapshot", () => {
+    expect(
+      renderToStaticMarkup(
+        <h1>
+          hello <span>my</span>
+          <h2>world</h2>
+          friend
+        </h1>
+      )
+    ).toMatchSnapshot();
+  });
+});

--- a/packages/davey-server/src/renderToStaticMarkup.ts
+++ b/packages/davey-server/src/renderToStaticMarkup.ts
@@ -1,7 +1,9 @@
 export interface Props {
-  children?: String[]
-  [key: string]: any
+  children?: String[];
+  [key: string]: any;
 }
+
+export type Tuple = [String, Props];
 
 const camelCase = str => {
   return str
@@ -41,18 +43,19 @@ const getIndent = index => {
   return `\n${[...Array.from({ length: index })].join("\t")}`;
 };
 
-const renderServer = ([tag, props, prevIndex = 0]) => {
+const renderServer = (elements, prevIndex = 0) => {
+  const [tag, props] = elements;
   const nextIndex = prevIndex + 1;
   const indent = getIndent(nextIndex);
-  const children =
-    typeof props.children[0] !== "string"
-      ? props.children.reduce((memo, child) => {
-          if (!child) return memo;
-          const [tag, props] = child;
-
-          return `${memo}${renderServer(child.concat(nextIndex))}`;
-        }, "")
-      : `${indent}\t${props.children[0]}`;
+  const children = Array.isArray(props.children)
+    ? props.children.reduce((memo, child) => {
+        return `${memo}${
+          Array.isArray(child)
+            ? renderServer(child, nextIndex)
+            : `${indent}\t${child}`
+        }`;
+      }, "")
+    : `${indent}\t${props.children}`;
 
   return `${indent}<${tag}${getAttrsServer(props)}>${children}${
     children ? indent : ""

--- a/packages/davey-store/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/davey-store/__tests__/__snapshots__/index.spec.tsx.snap
@@ -3,6 +3,7 @@
 exports[`getStore match snapshot 1`] = `
 Object {
   "get": [Function],
+  "listeners": Array [],
   "set": [Function],
   "subscribe": [Function],
 }

--- a/packages/davey-store/__tests__/index.spec.tsx
+++ b/packages/davey-store/__tests__/index.spec.tsx
@@ -2,7 +2,11 @@ import { davey } from "davey";
 import { createStore } from "davey-store";
 
 describe("getStore", () => {
-  const store = createStore({ active: false });
+  let store;
+
+  beforeEach(() => {
+    store = createStore({ active: false });
+  });
 
   test("match snapshot", () => {
     expect(store).toMatchSnapshot();
@@ -24,12 +28,17 @@ describe("getStore", () => {
   });
 
   describe("::subscribe", () => {
-    test("call listener ", () => {
-      let i = 0;
-      store.subscribe(data => {
-        expect(data.active).toEqual(i === 0 ? true : false);
+    let i = 0;
+
+    test(`call listener`, () => {
+      const removeFn = store.subscribe(data => {
+        expect(data.active).toEqual(i === 0 ? false : true);
         i++;
       });
+      store.set({ active: true });
+      
+      removeFn();
+      // This will break if listener isn't removed
       store.set({ active: false });
     });
   });

--- a/packages/davey-store/src/createStore.ts
+++ b/packages/davey-store/src/createStore.ts
@@ -3,7 +3,7 @@ export interface Data {
 }
 
 export default (store: Data) => {
-  const listeners = [];
+  let listeners = [];
 
   const get = () => store;
 
@@ -24,11 +24,12 @@ export default (store: Data) => {
     return () => {
       // Return handler removal function.
       const index = listeners.indexOf(handler);
-      return [...listeners.slice(0, index), ...listeners.slice(index + 1)];
+      listeners = [...listeners.slice(0, index), ...listeners.slice(index + 1)];
     };
   };
 
   return {
+    listeners,
     subscribe,
     set,
     get,

--- a/packages/davey/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/davey/__tests__/__snapshots__/index.spec.tsx.snap
@@ -1,5 +1,46 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`2-level deep nested element Resolves array of nodes match snapshot 1`] = `
+Array [
+  "div",
+  Object {
+    "children": Array [
+      1,
+      2,
+      3,
+    ],
+  },
+]
+`;
+
+exports[`2-level deep nested element Resolves text nodes match snapshot 1`] = `
+Array [
+  "h1",
+  Object {
+    "children": Array [
+      "hello ",
+      Array [
+        "span",
+        Object {
+          "children": Array [
+            "my",
+          ],
+        },
+      ],
+      Array [
+        "h2",
+        Object {
+          "children": Array [
+            "world",
+          ],
+        },
+      ],
+      "friend",
+    ],
+  },
+]
+`;
+
 exports[`2-level deep nested element match snapshot 1`] = `
 Array [
   "main",

--- a/packages/davey/__tests__/index.spec.tsx
+++ b/packages/davey/__tests__/index.spec.tsx
@@ -70,4 +70,24 @@ describe("2-level deep nested element", () => {
       "world"
     );
   });
+
+  describe("Resolves text nodes", () => {
+    const Component = (
+      <h1>
+        hello <span>my</span>
+        <h2>world</h2>
+        friend
+      </h1>
+    );
+    test("match snapshot", () => {
+      expect(Component).toMatchSnapshot();
+    });
+  });
+
+  describe("Resolves array of nodes", () => {
+    const Component = <div>{[1, 2, 3].map(val => val)}</div>;
+    test("match snapshot", () => {
+      expect(Component).toMatchSnapshot();
+    });
+  });
 });

--- a/packages/davey/index.ts
+++ b/packages/davey/index.ts
@@ -4,21 +4,20 @@ export interface Props {
 
 export type Tag = Function | String;
 
-const flattenFirstChild = val => {
+const flatten = val => {
   // First children can come down as arrays, strings or arrays of arrays.
   // TODO: Clean this up.
-  return val && val[0]
-    ? Array.isArray(val) && val.length > 2 ? [...val] : [val]
-    : [];
+  return val ? (Array.isArray(val) && val.length > 2 ? [...val] : [val]) : [];
 };
 
 export const davey = (tag: Tag, _props: Props, first, ...rest) => {
+  const children = first
+    ? flatten(first).concat(rest)
+    : _props && _props.children ? flatten(_props.children) : [];
+
   const props = {
     ..._props,
-    children: flattenFirstChild(first).concat(
-      rest,
-      _props && _props.children ? _props.children : []
-    ),
+    children,
   };
 
   return typeof tag === "function" ? tag(props) : [tag, props];


### PR DESCRIPTION
Children of mixed content (tags/text) were rendering incorrectly

fix #4, fix #5